### PR TITLE
なりすましログイン

### DIFF
--- a/app/controllers/administrators/application_controller.rb
+++ b/app/controllers/administrators/application_controller.rb
@@ -1,5 +1,4 @@
-class Administrators::ApplicationController < ActionController::Base
+class Administrators::ApplicationController < ApplicationController
   before_action :authenticate_administrator!
-  allow_browser versions: :modern
   layout 'administrators'
 end

--- a/app/controllers/administrators/home_controller.rb
+++ b/app/controllers/administrators/home_controller.rb
@@ -1,4 +1,0 @@
-class Administrators::HomeController < Administrators::ApplicationController
-  def index
-  end
-end

--- a/app/controllers/administrators/instructors/impersonations_controller.rb
+++ b/app/controllers/administrators/instructors/impersonations_controller.rb
@@ -1,0 +1,25 @@
+class Administrators::Instructors::ImpersonationsController < Administrators::ApplicationController
+  before_action :set_instructor
+  skip_before_action :authenticate_administrator!, only: %i[destroy]
+
+  def create
+    session[:administrator_backup_id] = current_administrator.id
+    sign_out current_administrator
+    sign_in @instructor
+    redirect_to instructors_root_path, notice: '講師として代理ログインしました。'
+  end
+
+  def destroy
+    sign_out current_instructor if instructor_signed_in?
+    administrator = Administrator.find(session[:administrator_backup_id])
+    session.delete(:administrator_backup_id)
+    sign_in administrator
+    redirect_to administrators_root_path, notice: '管理者に戻りました。'
+  end
+
+  private
+
+  def set_instructor
+    @instructor = Instructor.find(params.expect(:instructor_id))
+  end
+end

--- a/app/controllers/administrators/instructors/impersonations_controller.rb
+++ b/app/controllers/administrators/instructors/impersonations_controller.rb
@@ -1,20 +1,15 @@
 class Administrators::Instructors::ImpersonationsController < Administrators::ApplicationController
   before_action :set_instructor
-  skip_before_action :authenticate_administrator!, only: %i[destroy]
 
   def create
     session[:administrator_backup_id] = current_administrator.id
-    sign_out current_administrator
     sign_in @instructor
     redirect_to instructors_root_path, notice: '講師として代理ログインしました。'
   end
 
   def destroy
     sign_out current_instructor if instructor_signed_in?
-    administrator = Administrator.find(session[:administrator_backup_id])
-    session.delete(:administrator_backup_id)
-    sign_in administrator
-    redirect_to administrators_root_path, notice: '管理者に戻りました。'
+    redirect_to administrators_root_path, notice: '管理者に戻りました。', status: :see_other
   end
 
   private

--- a/app/controllers/administrators/instructors_controller.rb
+++ b/app/controllers/administrators/instructors_controller.rb
@@ -27,7 +27,7 @@ class Administrators::InstructorsController < Administrators::ApplicationControl
 
   def update
     if @instructor.update(instructor_params)
-      redirect_to administrators_instructor_path(@instructor), notice: '講師を更新しました。'
+      redirect_to administrators_instructor_path(@instructor), notice: '講師を更新しました。', status: :see_other
     else
       render :edit, status: :unprocessable_content
     end
@@ -35,7 +35,7 @@ class Administrators::InstructorsController < Administrators::ApplicationControl
 
   def destroy
     @instructor.destroy!
-    redirect_to administrators_instructors_path, notice: '講師を削除しました。'
+    redirect_to administrators_instructors_path, notice: '講師を削除しました。', status: :see_other
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   allow_browser versions: :modern
+
+  helper_method :impersonating?
+
+  def impersonating?
+    session[:administrator_backup_id].present?
+  end
 end

--- a/app/controllers/instructors/application_controller.rb
+++ b/app/controllers/instructors/application_controller.rb
@@ -1,5 +1,4 @@
-class Instructors::ApplicationController < ActionController::Base
+class Instructors::ApplicationController < ApplicationController
   before_action :authenticate_instructor!
-  allow_browser versions: :modern
   layout 'instructors'
 end

--- a/app/views/administrators/home/index.html.haml
+++ b/app/views/administrators/home/index.html.haml
@@ -1,2 +1,0 @@
-%h1 Administrator::Home#index
-%p Find me in app/views/administrator/home/index.html.haml

--- a/app/views/administrators/instructors/_form.html.haml
+++ b/app/views/administrators/instructors/_form.html.haml
@@ -1,33 +1,8 @@
-= simple_form_for [:administrators, instructor],
-                 html: { class: 'needs-validation', novalidate: true } do |f|
-  - if instructor.errors.any?
-    .alert.alert-danger
-      %h6 #{instructor.errors.count}件のエラーがあります：
-      %ul.mb-0
-        - instructor.errors.full_messages.each do |message|
-          %li= message
-
+= simple_form_for [:administrators, instructor] do |f|
   .row
-    .col-md-6
-      = f.input :name, label: '名前', required: true,
-                input_html: { class: 'form-control' }
-    .col-md-6
-      = f.input :email, label: 'メールアドレス', required: true,
-                input_html: { class: 'form-control' }
-
+    .col-md-6= f.input :name
+    .col-md-6= f.input :email
   .row
-    .col-md-6
-      = f.input :password, label: 'パスワード', required: instructor.new_record?,
-                input_html: { class: 'form-control',
-                              autocomplete: 'new-password' },
-                hint: instructor.persisted? ? '変更する場合のみ入力してください' : nil
-    .col-md-6
-      = f.input :password_confirmation, label: 'パスワード確認',
-                required: instructor.new_record?,
-                input_html: { class: 'form-control',
-                              autocomplete: 'new-password' }
-
-  .d-flex.gap-2
-    = f.submit (instructor.new_record? ? '作成' : '更新'), class: 'btn btn-primary'
-    = link_to 'キャンセル', administrators_instructors_path,
-              class: 'btn btn-secondary'
+    .col-md-6= f.input :password
+    .col-md-6= f.input :password_confirmation
+  = f.button :submit, class: 'btn-primary'

--- a/app/views/administrators/instructors/_form.html.haml
+++ b/app/views/administrators/instructors/_form.html.haml
@@ -1,8 +1,8 @@
 = simple_form_for [:administrators, instructor] do |f|
   .row
-    .col-md-6= f.input :name
-    .col-md-6= f.input :email
+    .col-6= f.input :name
+    .col-6= f.input :email
   .row
-    .col-md-6= f.input :password
-    .col-md-6= f.input :password_confirmation
+    .col-6= f.input :password
+    .col-6= f.input :password_confirmation
   = f.button :submit, class: 'btn-primary'

--- a/app/views/administrators/instructors/edit.html.haml
+++ b/app/views/administrators/instructors/edit.html.haml
@@ -1,4 +1,4 @@
-%h1.mb-4 #{@instructor.name}の編集
+%h1.fs-2.mb-4 #{@instructor.name}の編集
 
 .row.justify-content-center
   .col-lg-8

--- a/app/views/administrators/instructors/edit.html.haml
+++ b/app/views/administrators/instructors/edit.html.haml
@@ -1,7 +1,7 @@
 %h1.fs-2.mb-4 #{@instructor.name}の編集
 
 .row.justify-content-center
-  .col-lg-8
+  .col-8
     .card
       .card-body
         = render 'form', instructor: @instructor

--- a/app/views/administrators/instructors/index.html.haml
+++ b/app/views/administrators/instructors/index.html.haml
@@ -12,22 +12,14 @@
           %th 名前
           %th メールアドレス
           %th 最終ログイン
-          %th.text-center 操作
       %tbody
         - @instructors.each do |instructor|
           %tr
-            %td= instructor.name
+            %td= link_to instructor.name, administrators_instructor_path(instructor)
             %td= instructor.email
-            %td= instructor.last_sign_in_at&.strftime('%Y/%m/%d %H:%M')
-            %td.text-center
-              = link_to '詳細', administrators_instructor_path(instructor),
-                        class: 'btn btn-sm btn-outline-primary me-1'
-              = link_to '編集', edit_administrators_instructor_path(instructor),
-                        class: 'btn btn-sm btn-outline-secondary me-1'
-              = link_to '削除', administrators_instructor_path(instructor),
-                        class: 'btn btn-sm btn-outline-danger',
-                        data: { turbo_method: :delete,
-                                turbo_confirm: '本当に削除しますか？' }
+            %td
+              - if instructor.last_sign_in_at.present?
+                = l(instructor.last_sign_in_at)
 - else
   .alert.alert-info.text-center
     %p.mb-0 まだ講師が登録されていません。

--- a/app/views/administrators/instructors/index.html.haml
+++ b/app/views/administrators/instructors/index.html.haml
@@ -1,25 +1,22 @@
-%h1.mb-4 講師一覧
+%h1.fs-2.mb-4 講師一覧
 
-.d-flex.justify-content-end.mb-3
-  = link_to '新しい講師を追加', new_administrators_instructor_path,
-            class: 'btn btn-primary'
+.text-end.mb-3
+  = link_to '新しい講師を追加', new_administrators_instructor_path, class: 'btn btn-primary'
 
 - if @instructors.any?
-  .table-responsive
-    %table.table.table-striped.table-hover
-      %thead.table-dark
+  %table.table.table-hover
+    %thead.table-dark
+      %tr
+        %th 名前
+        %th メールアドレス
+        %th 最終ログイン
+    %tbody
+      - @instructors.each do |instructor|
         %tr
-          %th 名前
-          %th メールアドレス
-          %th 最終ログイン
-      %tbody
-        - @instructors.each do |instructor|
-          %tr
-            %td= link_to instructor.name, administrators_instructor_path(instructor)
-            %td= instructor.email
-            %td
-              - if instructor.last_sign_in_at.present?
-                = l(instructor.last_sign_in_at)
+          %td= link_to instructor.name, administrators_instructor_path(instructor)
+          %td= instructor.email
+          %td
+            - if instructor.last_sign_in_at.present?
+              = l(instructor.last_sign_in_at)
 - else
-  .alert.alert-info.text-center
-    %p.mb-0 まだ講師が登録されていません。
+  %p.text-center まだ講師が登録されていません。

--- a/app/views/administrators/instructors/new.html.haml
+++ b/app/views/administrators/instructors/new.html.haml
@@ -1,4 +1,4 @@
-%h1.mb-4 新しい講師を追加
+%h1.fs-2.mb-4 新しい講師を追加
 
 .row.justify-content-center
   .col-lg-8

--- a/app/views/administrators/instructors/new.html.haml
+++ b/app/views/administrators/instructors/new.html.haml
@@ -1,7 +1,7 @@
 %h1.fs-2.mb-4 新しい講師を追加
 
 .row.justify-content-center
-  .col-lg-8
+  .col-8
     .card
       .card-body
         = render 'form', instructor: @instructor

--- a/app/views/administrators/instructors/show.html.haml
+++ b/app/views/administrators/instructors/show.html.haml
@@ -1,6 +1,6 @@
 %h1.fs-2.mb-4 講師詳細
 
-.row
+.row.justify-content-center
   .col-lg-8
     .card
       .card-body
@@ -16,22 +16,22 @@
         %hr
 
         .row
-          .col-md-6
+          .col-6
             .mb-1
               %strong 登録日:
               = l(@instructor.created_at)
-          .col-md-6
+          .col-6
             .mb-1
               %strong 最終ログイン:
               - if @instructor.last_sign_in_at.present?
                 = l(@instructor.last_sign_in_at)
 
         .row
-          .col-md-6
+          .col-6
             .mb-1
               %strong ログイン回数:
               = @instructor.sign_in_count
-          .col-md-6
+          .col-6
             .mb-1
               %strong アカウント状態:
               - if @instructor.confirmed_at
@@ -41,6 +41,6 @@
 
     .d-flex.gap-2.mt-4.justify-content-between
       = link_to '編集', edit_administrators_instructor_path(@instructor), class: 'btn btn-primary'
-      = button_to 'この講師でログインする', administrators_instructor_impersonation_path(@instructor), class: 'btn btn-outline-secondary', data: { turbo_confirm: 'この講師としてログインしますか？' }
+      = button_to 'この講師でログインする', administrators_instructor_impersonation_path(@instructor), class: 'btn btn-outline-success', data: { turbo_confirm: 'この講師としてログインしますか？' }
       .ms-auto
         = button_to '削除', administrators_instructor_path(@instructor), method: :delete, data: { turbo_confirm: '本当にこの講師を削除しますか？' }, class: 'btn btn-danger'

--- a/app/views/administrators/instructors/show.html.haml
+++ b/app/views/administrators/instructors/show.html.haml
@@ -1,54 +1,46 @@
-%h1.mb-4 講師詳細
+%h1.fs-2.mb-4 講師詳細
 
 .row
   .col-lg-8
     .card
       .card-body
-        %h5.card-title= @instructor.name
-        %p.card-text
+        .fs-5.card-title= @instructor.name
+        .card-text
           %strong メールアドレス:
           = @instructor.email
 
-        %p.card-text
+        .card-text
           %strong 自己紹介:
-        %p.card-text.border.p-3.bg-light= h(@instructor.introduction)
+        .card-text.border.p-3.bg-light= @instructor.introduction
 
         %hr
 
         .row
           .col-md-6
-            %p.mb-1
+            .mb-1
               %strong 登録日:
-              = @instructor.created_at.strftime('%Y年%m月%d日')
+              = l(@instructor.created_at)
           .col-md-6
-            %p.mb-1
+            .mb-1
               %strong 最終ログイン:
-              = @instructor.last_sign_in_at&.strftime('%Y年%m月%d日 %H:%M') || '未ログイン'
+              - if @instructor.last_sign_in_at.present?
+                = l(@instructor.last_sign_in_at)
 
         .row
           .col-md-6
-            %p.mb-1
+            .mb-1
               %strong ログイン回数:
               = @instructor.sign_in_count
           .col-md-6
-            %p.mb-1
+            .mb-1
               %strong アカウント状態:
               - if @instructor.confirmed_at
                 %span.badge.bg-success 確認済み
               - else
                 %span.badge.bg-warning 未確認
 
-    .d-flex.gap-2.mt-4
-      = link_to '編集', edit_administrators_instructor_path(@instructor),
-                class: 'btn btn-primary'
-      = link_to '削除', administrators_instructor_path(@instructor),
-                class: 'btn btn-danger',
-                data: { turbo_method: :delete,
-                        turbo_confirm: '本当に削除しますか？' }
-      = link_to '一覧に戻る', administrators_instructors_path,
-                class: 'btn btn-secondary'
+    .d-flex.gap-2.mt-4.justify-content-between
+      = link_to '編集', edit_administrators_instructor_path(@instructor), class: 'btn btn-primary'
+      = button_to 'この講師でログインする', administrators_instructor_impersonation_path(@instructor), class: 'btn btn-outline-secondary', data: { turbo_confirm: 'この講師としてログインしますか？' }
       .ms-auto
-        = button_to 'この講師でログインする',
-                    administrators_instructor_impersonation_path(@instructor),
-                    class: 'btn btn-outline-secondary',
-                    data: { turbo_confirm: 'この講師としてログインしますか？' }
+        = button_to '削除', administrators_instructor_path(@instructor), method: :delete, data: { turbo_confirm: '本当にこの講師を削除しますか？' }, class: 'btn btn-danger'

--- a/app/views/administrators/instructors/show.html.haml
+++ b/app/views/administrators/instructors/show.html.haml
@@ -38,12 +38,17 @@
               - else
                 %span.badge.bg-warning 未確認
 
-.d-flex.gap-2.mt-4
-  = link_to '編集', edit_administrators_instructor_path(@instructor),
-            class: 'btn btn-primary'
-  = link_to '削除', administrators_instructor_path(@instructor),
-            class: 'btn btn-danger',
-            data: { turbo_method: :delete,
-                    turbo_confirm: '本当に削除しますか？' }
-  = link_to '一覧に戻る', administrators_instructors_path,
-            class: 'btn btn-secondary'
+    .d-flex.gap-2.mt-4
+      = link_to '編集', edit_administrators_instructor_path(@instructor),
+                class: 'btn btn-primary'
+      = link_to '削除', administrators_instructor_path(@instructor),
+                class: 'btn btn-danger',
+                data: { turbo_method: :delete,
+                        turbo_confirm: '本当に削除しますか？' }
+      = link_to '一覧に戻る', administrators_instructors_path,
+                class: 'btn btn-secondary'
+      .ms-auto
+        = button_to 'この講師でログインする',
+                    administrators_instructor_impersonation_path(@instructor),
+                    class: 'btn btn-outline-secondary',
+                    data: { turbo_confirm: 'この講師としてログインしますか？' }

--- a/app/views/layouts/_administrator_sidebar.html.haml
+++ b/app/views/layouts/_administrator_sidebar.html.haml
@@ -2,8 +2,6 @@
   .sidebar__logo 管理者: Asia Language
   %ul.sidebar__list
     %li.sidebar__list-link
-      = link_to 'ダッシュボード', administrators_root_path, class: 'text-decoration-none text-white'
-    %li.sidebar__list-link
       = link_to '講師管理', administrators_instructors_path, class: 'text-decoration-none text-white'
-    %li.sidebar__list-link
-      = link_to 'ログアウト', destroy_administrator_session_path, method: :delete, class: 'text-decoration-none text-white', data: { confirm: 'ログアウトしますか？' }
+  - if administrator_signed_in?
+    .p-2= button_to 'ログアウト', destroy_administrator_session_path, method: :delete, data: { turbo_confirm: 'ログアウトします、よろしいですか？' }, class: 'btn btn-danger'

--- a/app/views/layouts/_instructor_sidebar.html.haml
+++ b/app/views/layouts/_instructor_sidebar.html.haml
@@ -1,6 +1,10 @@
 .sidebar.is-instructor
   .sidebar__logo 講師: Asia Language
+  - if impersonating?
+    .alert.alert-warning.m-3
+      管理者で代理ログイン中
+      = button_to 'なりすましログインを終了', administrators_instructor_impersonation_path(current_instructor), method: :delete, data: { turbo_confirm: '管理者に戻ります、よろしいですか？' }, class: 'btn btn-outline-secondary'
   %ul.sidebar__list
     %li.sidebar__list-link Item1
     %li.sidebar__list-link Item2
-    %li.sidebar__list-link Item3
+    %li.sidebar__list-link Item

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -9,6 +9,8 @@ ja:
         password: パスワード
         remember_me: ログインを記憶する
       instructor:
+        name: 名前
         email: メールアドレス
         password: パスワード
+        password_confirmation: パスワード（確認用）
         remember_me: ログインを記憶する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   devise_for :administrators, controllers: { sessions: 'administrators/sessions' }
 
   namespace :administrators do
-    root 'home#index'
+    root 'instructors#index'
     resources :instructors, only: %i[index show new edit create update destroy] do
       resource :impersonation, only: %i[create destroy], module: :instructors
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
 
   namespace :administrators do
     root 'home#index'
-    resources :instructors, only: %i[index show new edit create update destroy]
+    resources :instructors, only: %i[index show new edit create update destroy] do
+      resource :impersonation, only: %i[create destroy], module: :instructors
+    end
   end
 
   namespace :instructors do


### PR DESCRIPTION
管理者が講師になりすましてログインできるようにする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Administrators can impersonate an instructor and return to admin. An in-app banner indicates impersonation with a one-click “end” action.

- UI Changes
  - Simplified instructor form with cleaner inputs and submit button.
  - Updated page headings for clearer hierarchy.
  - Streamlined instructors list: names are clickable; actions column removed; last login shown when available with localized format.
  - Refreshed instructor details page with localized dates and reorganized actions, including “Log in as this instructor.”

- Localization
  - Added Japanese labels for Instructor “名前” and “パスワード（確認用）”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->